### PR TITLE
Update jquery.SPServices.js

### DIFF
--- a/src/jquery.SPServices.js
+++ b/src/jquery.SPServices.js
@@ -481,13 +481,13 @@
         // Build the URL for the Ajax call based on which operation we're calling
         // If the webURL has been provided, then use it, else use the current site
         var ajaxURL = "_vti_bin/" + WSops[opt.operation][0] + ".asmx";
-        var thisSite = $().SPServices.SPGetCurrentSite();
         var webURL = opt.webURL !== undefined ? opt.webURL : opt.webUrl;
         if (webURL.charAt(webURL.length - 1) === SLASH) {
             ajaxURL = webURL + ajaxURL;
         } else if (webURL.length > 0) {
             ajaxURL = webURL + SLASH + ajaxURL;
         } else {
+            var thisSite = $().SPServices.SPGetCurrentSite();
             ajaxURL = thisSite + ((thisSite.charAt(thisSite.length - 1) === SLASH) ? ajaxURL : (SLASH + ajaxURL));
         }
 


### PR DESCRIPTION
Currently SPGetCurrentSite is called in case of a given webURL as well. If the page containing the script is not stored inside a SharePoint Site then the current site can't retrieved and on each call to SPServices the call is tried and failed again. Szenario: While developing I host my Markup locally and use SharePoint just as a generic service backend)

The local var thisSite is used inside the last else only. So I suggest to move the line into this last scope.