### PR TITLE
Extended SPGetListItemsJson with reject support

### DIFF
--- a/src/jquery.SPServices.js
+++ b/src/jquery.SPServices.js
@@ -3599,6 +3599,10 @@
             contains: opt.contains
         });
 
+		thisData.fail(function (a, b, c) {
+			result.reject(a, b, c);
+		});
+
         thisData.done(function () {
 
             var mappingKey = "SPGetListItemsJson" + opt.webURL + opt.listName;


### PR DESCRIPTION
If an error occoured e.g. in parsing the XML the error was not logged/shown/forwarded anywhere.