### PR TITLE
SPFilterDropdown & cascadeDropdown bug

### DIFF
--- a/src/jquery.SPServices.js
+++ b/src/jquery.SPServices.js
@@ -1746,7 +1746,7 @@
 
                         switch (childSelect.Type) {
                             case dropdownType.simple:
-                                var selected = ($(this).attr("ows_ID") === childSelectSelected[0]) ? " selected='selected'" : "";
+                                var selected = (thisOption.id === childSelectSelected[0]) ? " selected='selected'" : "";
                                 childSelect.Obj.append("<option" + selected + " value='" + thisOption.id + "'>" + thisOption.value + "</option>");
                                 break;
                             case dropdownType.complex:
@@ -2276,7 +2276,7 @@
 
                     switch (columnSelect.Type) {
                         case dropdownType.simple:
-                            var selected = ($(this).attr("ows_ID") === columnSelectSelected[0]) ? " selected='selected'" : "";
+                            var selected = (thisOption.id === columnSelectSelected[0]) ? " selected='selected'" : "";
                             columnSelect.Obj.append("<option" + selected + " value='" + thisOption.id + "'>" + thisOption.value + "</option>");
                             break;
                         case dropdownType.complex:

--- a/src/jquery.SPServices.js
+++ b/src/jquery.SPServices.js
@@ -3445,7 +3445,7 @@
         for (var i = 0; i < qs.length; i++) {
             var param = qs[i].split('=');
             var paramName = opt.lowercase ? param[0].toLowerCase() : param[0];
-            queryStringVals[paramName] = decodeURIComponent(param[1] || "").replace(/\+/g, ' ');
+            queryStringVals[paramName] = decodeURIComponent(param[1] || "");
         }
 
         return queryStringVals;

--- a/src/jquery.SPServices.js
+++ b/src/jquery.SPServices.js
@@ -3445,7 +3445,7 @@
         for (var i = 0; i < qs.length; i++) {
             var param = qs[i].split('=');
             var paramName = opt.lowercase ? param[0].toLowerCase() : param[0];
-            queryStringVals[paramName] = decodeURIComponent(param[1] || "");
+            queryStringVals[paramName] = decodeURIComponent(param[1] || "").replace(/\+/g, ' ');
         }
 
         return queryStringVals;


### PR DESCRIPTION
Fixed problem with setting selected option of simple selects when the field is a lookup. In this case thisOption.id !== $(this).attr("ows_ID")

Where this shows up:

List "Cities"
ID  Title
1    Aberdean
2    Alleen
3    Dallas

List "City Countries"
ID City                  Title
1   3;#Dallas         USA
2   1;#Aberdean   Mexico
3  2;#Alleen         Canada

If you have a list with a lookup to Cities and a list item with "Alleen" selected. If you try to use SPFilterDropdown to filter it to just cities in Canada by querying "City Countries" for cities in Canada the "GetListItems" call will return the row with ID 3. In this case it uses "$(this).attr("ows_ID") === columnSelectSelected[0]" to tell if the newly created option was originally selected. 

At this point:
columnSelectSelected[0] = 2 //ID of city Alleen
$(this).attr("ows_ID") = 3 //ID of row in "City Countries"
thisOption.id = 2 //ID split from City lookup 2;#Alleen
