### PR TITLE
Gruntfile now processes variables of built files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -182,6 +182,16 @@ module.exports = function(grunt) {
                 ],
                 dest:   "<%= userBuildOpt.deployLocation %>",
                 expand: true
+            },
+
+            processBuildVariables: {
+                options : {
+                    processContent: function(fileContent, filePath){
+                        return replaceBuildVariables(fileContent, filePath);
+                    }
+                },
+                src:    "build/<%= pkg.filename %>.js",
+                dest:   "build/<%= pkg.filename %>.js"
             }
         },
 
@@ -324,6 +334,7 @@ module.exports = function(grunt) {
         'jshint',
         'requirejs:compile',
         'concat',
+        'copy:processBuildVariables',
         'uglify',
         'zip'
     ]);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -8,7 +8,7 @@ define([], function(){
     var constants = {
 
         // Version info
-        VERSION: "2.0.0", // TODO: Update version
+        VERSION: "@VERSION", // update it in package.json... build takes care of the rest
 
         // Simple strings
         spDelim:            ";#",


### PR DESCRIPTION
Changes made:

- Added new copy task to gruntfile that will process built files
  (those in build/) and replace build variables
- Changed VERSION constant value to be @VERSION build variable

So now, whenever you want to cut a new release, just update the version number in the `package.json` file, and then run a build. 