### PR TITLE
fixed bug with findFormField util

### DIFF
--- a/src/core/SPServices.utils.js
+++ b/src/core/SPServices.utils.js
@@ -188,20 +188,22 @@ define([
         //      FieldType="SPFieldText"
         //  -->
         // as the "anchor" to find it. Necessary because SharePoint doesn't give all field types ids or specific classes.
-        findFormField: function(columnName) {
-            var thisFormBody;
-            // There's no easy way to find one of these columns; we'll look for the comment with the columnName
-            var searchText = new RegExp("FieldName=\"" + columnName.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&") + "\"", "gi");
-            // Loop through all of the ms-formbody table cells
-            $("td.ms-formbody, td.ms-formbodysurvey").each(function () {
-                // Check for the right comment
-                if (searchText.test($(this).html())) {
-                    thisFormBody = $(this);
-                    // Found it, so we're done
-                    return false;
-                }
-            });
-            return thisFormBody;
+        findFormField: function(v) {
+            var $formBody = $("td.ms-formbody, td.ms-formbodysurvey"),
+                // Borrowed from MDN.
+                // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+                escapeRegExp = function (v){
+                    return v.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+                },
+                columnName = escapeRegExp(v),
+                rcommentValidation = new RegExp("(?:Field|FieldInternal)Name=\"" + columnName + "\"", "i"),
+                $columnNode = $formBody.contents().filter(function () {
+                    return this.nodeType === 8 && rcommentValidation.test(this.nodeValue);
+                })
+
+            ;
+
+            return $columnNode.parent("td");
         }, // End of function findFormField
 
         // Show a single attribute of a node, enclosed in a table


### PR DESCRIPTION
This find the comment nodes and only checks the comment nodes, not the full HTML. I found a bug with the previous method in that it would return the incorrect td if a textarea had a value of FieldName="ColumnName". This new function also allows usage of the static name.

http://jsfiddle.net/iOnline247/zfdLq4cw/